### PR TITLE
fix font-color of jsPanel title

### DIFF
--- a/src/FloatingWindow.ts
+++ b/src/FloatingWindow.ts
@@ -36,7 +36,7 @@ export class FloatingWindow {
 window.addEventListener("unload", function(e) {
     // save panel layout
     jsPanel.layout.save({
-        selector:    '.jsPanel-standard',
+        selector:    '.jsPanel-stupidconsole',
         storagename: 'stupid-console-jsPanel'
     });
 });

--- a/src/Gui.ts
+++ b/src/Gui.ts
@@ -24,7 +24,8 @@ export class Gui {
         let window = new FloatingWindow({
             theme : "primary",
             headerTitle : _title,
-            content : container
+            content : container,
+            paneltype: 'stupidconsole'
         });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import {FloatingWindow} from "./FloatingWindow.js";
 new FloatingWindow({
     theme : "primary",
     headerTitle : "console",
-    content : consoleContainer
+    content : consoleContainer,
+    paneltype: 'stupidconsole'
 });
 
 export default {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,18 +1,11 @@
 
-.jsPanel .jsPanel-content, .jsPanel-titlebar .jsPanel-title {
+.jsPanel.jsPanel-stupidconsole .jsPanel-content, .jsPanel-stupidconsole .jsPanel-titlebar .jsPanel-title {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     font-size: 16px;
     font-weight: normal;
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
-    background: #fff;
-    color: #666;
     font-variant: normal;
-}
-
-.jsPanel-titlebar .jsPanel-title {
-    background: transparent;
-    color: #fff;
 }
 
 .console-events .uk-icon {


### PR DESCRIPTION
First of all thanks for using jsPanel 😄 
I noticed a small issue with the font-color of the title because you "hardcoded" it to be white. That means the mechanism that chooses font-color based on theme color doesn't work and all jsPanels in the document will use a white font-color even if, for example, an all white panel would need a dark font-color.
I made two changes I'd like you to check out:
+ use of jsPanel option [paneltype](https://jspanel.de/api.html#options/paneltype) with the value `"stupidconsole"` in order to have a paneltype that is distinguishable from non-StupidConsole panels. So instead of the classname `"jsPanel-standard"` the StupdiConsole panels have the classname `"jsPanel-stupidconsole"`
+ updated the css to make use of the new paneltype

With these changes other jsPanels have the intended title font-color, no matter what theme color is used. I hope I didn't miss anything ...

Regards,
Stefan (Flyer53)
